### PR TITLE
update wording on the official email verif page

### DIFF
--- a/cypress/e2e/join_with_code_sent_to_official_contact_email/index.cy.ts
+++ b/cypress/e2e/join_with_code_sent_to_official_contact_email/index.cy.ts
@@ -14,7 +14,7 @@ describe("join organizations", () => {
 
     // Check that the website is waiting for the user to verify their email
     cy.contains(
-      "nous avons envoyé un code secret à l’adresse email de votre mairie",
+      "nous avons envoyé un code à l’adresse email officielle de votre mairie",
     );
     cy.get(".email-badge-lowercase").contains(
       "alpharius.omegon@alphalegion.world",

--- a/cypress/e2e/join_with_code_sent_to_official_educ_nat_contact_email/index.cy.ts
+++ b/cypress/e2e/join_with_code_sent_to_official_educ_nat_contact_email/index.cy.ts
@@ -10,7 +10,7 @@ describe("join organizations", () => {
 
     // Check that the website is waiting for the user to verify their email
     cy.contains(
-      "nous avons envoyé un code secret à l’adresse email de votre établissement scolaire",
+      "nous avons envoyé un code à l’adresse email officielle de votre établissement scolaire",
     );
     cy.get(".email-badge-lowercase").contains("rogal.dorn@imperialfists.world");
 

--- a/src/views/user/join-organization-confirm.ejs
+++ b/src/views/user/join-organization-confirm.ejs
@@ -8,12 +8,12 @@
         <p>
             Un email professionnel (ex : votre-entreprise.com) a plus de chance d’être validé par notre équipe de modération.
         </p>
-        <ul class="fr-btns-group fr-btns-group--sm fr-btns-group--inline-sm">
+        <ul class="fr-btns-group fr-btns-group--sm">
             <li>
                 <a
                 href="/users/start-sign-in"
                 aria-label="Corriger l’email <%= email; %>"
-                class="fr-btn fr-btn--secondary"
+                class="fr-btn fr-btn--primary"
                 >
                 Corriger l’email
                 </a>

--- a/src/views/user/official-contact-email-verification.ejs
+++ b/src/views/user/official-contact-email-verification.ejs
@@ -27,13 +27,13 @@
                            autocomplete="off">
                 </div>
                 <%- include('../partials/submit-button.ejs', {label: 'Valider'}) %>
-                    <div class="fr-alert fr-alert--info">
-                     <p>
+                <div class="fr-alert fr-alert--info fr-mt-2w">
+                    <p>
                         Cette adresse email n’est plus à jour ?
                     </p>
-                     <p>
-                         <a class="fr-link" href="https://lannuaire.service-public.fr/" target="_blank">
-                        Modifiez-la sur l’annuaire du service public.
+                    <p>
+                        <a class="fr-link" href="https://lannuaire.service-public.fr/" target="_blank">
+                            Modifiez-la sur l’annuaire du service public.
                         </a>
                     </p>
                 </div>
@@ -41,5 +41,4 @@
             </form>
         </div>
     </div>
-
 </div>

--- a/src/views/user/official-contact-email-verification.ejs
+++ b/src/views/user/official-contact-email-verification.ejs
@@ -2,13 +2,13 @@
     <%- include('../partials/notifications.ejs', {notifications: notifications, noWrapperDiv: true}) %>
     <div class="fr-mb-2w">
         <h1 class="fr-h3">
-            Vérifier votre email
+            Vérifier votre adresse email
         </h1>
         <div>
             <form id="verify-email" action="/users/official-contact-email-verification/<%= organization_id %>" method="post" autocomplete="off">
                 <p>
                     Pour vérifier votre appartenance à l’organisation <%= libelle %>,
-                    nous avons envoyé un <% if (newCodeSent) { %>nouveau <% } %>code secret à l’adresse email de votre <%= organization_type_label; %> :
+                    nous avons envoyé un <% if (newCodeSent) { %>nouveau <% } %>code à l’adresse email officielle de votre <%= organization_type_label; %> :
                     <span class="fr-badge fr-badge--info fr-badge--no-icon email-badge-lowercase">
                         <%= contactEmail; %>
                     </span>.
@@ -27,18 +27,19 @@
                            autocomplete="off">
                 </div>
                 <%- include('../partials/submit-button.ejs', {label: 'Valider'}) %>
+                    <div class="fr-alert fr-alert--info">
+                     <p>
+                        Cette adresse email n’est plus à jour ?
+                    </p>
+                     <p>
+                         <a class="fr-link" href="https://lannuaire.service-public.fr/" target="_blank">
+                        Modifiez-la sur l’annuaire du service public.
+                        </a>
+                    </p>
+                </div>
                 <%- include('../partials/go-back.ejs') %>
             </form>
         </div>
     </div>
-    <div class="fr-alert fr-alert--info">
-        <p>
-            Cette adresse email n’est pas à jour.
-        </p>
-        <p>
-            <a class="fr-link fr-fi-arrow-right-line fr-link--icon-left" href="https://lannuaire.service-public.fr/">
-                Faire une demande de mise à jour sur l’annuaire du service public.
-            </a>
-        </p>
-    </div>
+
 </div>


### PR DESCRIPTION
avant la campagne du FS de l'Apostille :
Page de confirm d'utilisation d'un email perso : 
- supression de l'affichage inline
- passage du btn "corriger" en primary
- 
<img width="907" alt="Capture d’écran 2025-03-12 à 15 12 55" src="https://github.com/user-attachments/assets/e752a84b-8d7c-49f6-bf02-0ccd8c405fb6" />

Page de vérif d'email officiel
- met à jour des wordings  
- met à jour le lien de l'annuaire des services publics
- déplace le banner info avant le btn retour

<img width="369" alt="Capture d’écran 2025-03-12 à 15 15 18" src="https://github.com/user-attachments/assets/05080dbe-afa2-476a-8136-b9ab17572a7a" />
