### PR TITLE
chore(docker): add maildev healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,12 @@ services:
 
   maildev:
     image: soulteary/maildev
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:1080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     network_mode: "host"
 
 volumes:


### PR DESCRIPTION
It's somehow a fix has the default healthcheck seems to fail with network_mode: "host"