### PR TITLE
ci(release): use pnpm to publish packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: changesets/action@v1
         with:
           commit: "🔖 Version Packages"
-          publish: npx changeset publish
+          publish: pnpm publish -r
           title: "🔖 Version Packages"
           version: npm run version
         env:


### PR DESCRIPTION
Will be useful for separating the external and internal package use
\see https://pnpm.io/package_json#publishconfig