### PR TITLE
a11y(logo): removes the ‘logo’ specification from art

### DIFF
--- a/packages/email/src/components/ProConnectLogo.tsx
+++ b/packages/email/src/components/ProConnectLogo.tsx
@@ -4,7 +4,7 @@ export function ProConnectLogo() {
   return (
     <img
       src="https://identite.proconnect.gouv.fr/dist/mail-proconnect.png"
-      alt="ProConnect Logo"
+      alt="ProConnect"
       height={73}
       width={193}
     />


### PR DESCRIPTION
<p align="center"><img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2pncXZpbGJodTJrMXFoMmM5ZmNmczAxY2ppaWM5Y3U5MTU4ZW9tdyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/FBJHTakvaHY6Q/giphy.gif"></p>