### PR TITLE
a11y(btn) : replace return by cancel

### DIFF
--- a/src/views/partials/go-back.ejs
+++ b/src/views/partials/go-back.ejs
@@ -1,8 +1,4 @@
 <div class="fr-mt-2w">
-  <button
-    class="fr-btn fr-btn--tertiary fr-icon-arrow-go-back-line fr-btn--icon-left go-back-link"
-  >
-    retour
-  </button>
+  <button class="fr-btn fr-btn--tertiary go-back-link">Annuler</button>
 </div>
 <script type="module" src="<%= js('go-back.js') %>"></script>


### PR DESCRIPTION
Message from Sophie : "The title of the ‘back’ button is not self-explanatory. Replace it with ‘Cancel’ and remove the icon indicating a backtrack, as it will not provide any additional information."